### PR TITLE
Add semijoins

### DIFF
--- a/lib/related/operations/semi_join.rb
+++ b/lib/related/operations/semi_join.rb
@@ -1,0 +1,28 @@
+module Related
+  module Operations
+    def left_semi_join(other)
+      mapping = schema.join_mapping_for other.schema
+      Relation.new(schema.similar) do |r|
+        each do |tuple|
+          other.each do |other_tuple|
+            r.add_tuple tuple if tuple.matches?(other_tuple, index_mapping: mapping)
+          end
+        end
+      end
+    end
+    alias ⋉ left_semi_join
+    alias semi_join left_semi_join
+
+    def right_semi_join(other)
+      mapping = schema.join_mapping_for other.schema
+      Relation.new(other.schema.similar) do |r|
+        each do |tuple|
+          other.each do |other_tuple|
+            r.add_tuple other_tuple if tuple.matches?(other_tuple, index_mapping: mapping)
+          end
+        end
+      end
+    end
+    alias ⋊ right_semi_join
+  end
+end

--- a/lib/related/relation.rb
+++ b/lib/related/relation.rb
@@ -95,5 +95,9 @@ module Related
     def to_s
       to_table
     end
+
+		def clone
+			Relation.new @schema.clone, @tuples.clone
+		end
   end
 end

--- a/lib/related/schema.rb
+++ b/lib/related/schema.rb
@@ -58,6 +58,17 @@ module Related
       @index_hash[key]
     end
 
+    # Calculate indexes mapping between two schemas
+    # example: [[1, 4], [2, 3]] would mean that during a join
+    # a left value at index 1 should be compared with a right at 4
+    def join_mapping_for(other)
+      mapping = []
+      (names & other.names).each do |name|
+        mapping << [index_for(name), other.index_for(name)]
+      end
+      mapping
+    end
+
     private
 
     def build_schema_from_hash(hash)

--- a/lib/related/tuple.rb
+++ b/lib/related/tuple.rb
@@ -40,6 +40,13 @@ module Related
       values.hash
     end
 
+    def matches?(other, index_mapping:)
+      index_mapping.each do |i, j|
+        return false if values[i] != other.values[j]
+      end
+      true
+    end
+
     private
 
     def values_for(other)

--- a/spec/units/operations_spec.rb
+++ b/spec/units/operations_spec.rb
@@ -57,4 +57,24 @@ describe Operations do
       expect(theta_join).to eq(result)
     end
   end
+
+  context "#⋉, semi_join, left_semi_join" do
+    it 'performs a left semi join' do
+      result = people.clone
+      people.add_tuple ['No-counterpart', 44, 'male']
+      expect( people.semi_join favorites ).to eq(result)
+    end
+  end
+
+  context "#⋊, right_semi_join" do
+    it 'performs a right semi join' do
+      result = Relation.new do |r|
+        r.schema = Schema.new(name: String, pizza: String)
+        r.add_tuple ['Amy', 'mushroom']
+        r.add_tuple ['Amy', 'pepperoni']
+        r.add_tuple ['Ben', 'cheese']
+      end
+      expect( people.right_semi_join favorites ).to eq(result)
+    end
+  end
 end

--- a/spec/units/relation_spec.rb
+++ b/spec/units/relation_spec.rb
@@ -37,6 +37,14 @@ describe Relation do
     end
   end
 
+	context '#clone' do
+		it "doesn't change when tuples are added to the original" do
+			clone = people.clone
+			people.add_tuple ['New', 25, 'female']
+			expect(clone).to_not include ['New', 25, 'female']
+		end
+	end
+
   context "#⋈, natural_join" do
     it 'performs a natural join' do
       result = Relation.new do |r|


### PR DESCRIPTION
This commit introduces left and right semijoins and few helper
functions. Schema#join_mapping_for finds indexes which correspond
during join. This result map is then a parameter for Tuple#matches?

Tests are provided and Relation#clone made them a bit cleaner to write.
