### PR TITLE
Add difference tests and alias

### DIFF
--- a/lib/related/relation.rb
+++ b/lib/related/relation.rb
@@ -75,10 +75,12 @@ module Related
     end
     alias ∪ union
 
-    def -(other)
+    def difference(other)
       raise ArgumentError unless schema == other.schema
       Relation.new(schema, @tuples - other.tuples)
     end
+    alias - difference
+    alias / difference
 
     def include?(other)
       @tuples.each do |tuple|

--- a/spec/units/relation_spec.rb
+++ b/spec/units/relation_spec.rb
@@ -134,6 +134,24 @@ describe Relation do
     end
   end
 
+  context "#/, #-, #difference" do
+    it 'performs the difference' do
+      people2 = Relation.new do |r|
+        r.schema = Schema.new(name: String, age: Numeric, gender: String)
+        r.add_tuple ['Ben', 21, 'male']
+        r.add_tuple ['Gus', 45, 'male']
+      end
+
+      difference = people.difference(people2)
+      result = Relation.new do |r|
+        r.schema = Schema.new(name: String, age: Numeric, gender: String)
+        r.add_tuple ['Amy', 16, 'female']
+      end
+
+      expect(difference).to eq(result)
+    end
+  end
+
   context "#×, cross_product" do
     it 'performs the cartesian product' do
       cross = people.cross_product(menu)


### PR DESCRIPTION
Relation difference was missing a test and had unconventional naming.
For a name it had only a '-' symbol, without a long name (like union
operator has).

Codd's relation algebra uses the set difference denoted by '/'.
https://en.wikipedia.org/wiki/Relational_algebra

This change:
- adds a test
- adds #difference and #/ alias
