### PR TITLE
Refactor schema constructor

### DIFF
--- a/lib/related/schema.rb
+++ b/lib/related/schema.rb
@@ -6,8 +6,8 @@ module Related
   class Schema
     attr_accessor :heading
     def initialize(input)
-      build_schema_from_hash input if input.is_a? Hash
-      build_schema_from_array input if input.is_a? Array
+      @type_hash = input.to_h()
+      @heading = input.to_a()
     end
 
     def similar
@@ -59,16 +59,6 @@ module Related
     end
 
     private
-
-    def build_schema_from_hash(hash)
-      @type_hash = hash
-      @heading = hash.to_a
-    end
-
-    def build_schema_from_array(ary)
-      @type_hash = ary.to_h
-      @heading = ary
-    end
 
     def build_index_hash
       @index_hash = {}

--- a/spec/units/schema_spec.rb
+++ b/spec/units/schema_spec.rb
@@ -16,6 +16,13 @@ describe Schema do
     end
   end
 
+  context 'built from array' do
+    it 'is equal to built from hash' do
+      from_hash = Schema.new [[:name, String], [:age, Numeric], [:gender, String]]
+      expect(from_hash).to eq(schema)
+    end
+  end
+
   context '#rename' do
     it 'takes a hash of attributes to rename and returns a new schema' do
       result = described_class.new(name: String, age: Numeric, sex: String)


### PR DESCRIPTION
Instead of checking a type of parameter, its faster in runtime and
shorter in code to run to_h() and to_a() conversion methods. If input
is a hash, to_h() will not change it.
