### PR TITLE
Rewrite natural join, refactor semi-joins

### DIFF
--- a/lib/related/operations/natural_join.rb
+++ b/lib/related/operations/natural_join.rb
@@ -1,39 +1,19 @@
 module Related
   module Operations
     def natural_join(other)
-      NaturalJoin.new(self, other).call
+      mapping = schema.join_mapping_for other.schema
+      Relation.new do |r|
+        r.schema = Schema.new((schema.heading + other.schema.heading).uniq)
+        cross_action other do |tuple, other_tuple|
+          if tuple.matches? other_tuple, mapping: mapping
+            # reject to avoid duplications on join columns
+            join_indexes = mapping.map(&:last)
+            other_values = other_tuple.values.reject.with_index {|_,i| join_indexes.include? i}
+            r.add_tuple Tuple.new(tuple.values + other_values)
+          end
+        end
+      end
     end
     alias ⋈ natural_join
-
-    class NaturalJoin
-      def initialize(r1, r2)
-        @r1 = r1
-        @r2 = r2
-      end
-
-      def call
-        join = @r1.cross_product( @r2.rename(rename_hash) )
-        select = join.select { |t| rename_hash.all? { |k, v| t[k] == t[v] } }
-        select.project( result_keys )
-      end
-
-      private
-
-      def rename_hash
-        return @rename_hash if @rename_hash
-        common_attributes = @r1.schema.names & @r2.schema.names
-        @rename_hash = {}
-        common_attributes.each do |attr|
-          old_key, = @r2.schema.heading.assoc(attr)
-          @rename_hash[old_key] = old_key.to_s.concat('_temp').to_sym
-        end
-
-        @rename_hash
-      end
-
-      def result_keys
-        @r1.schema.names | @r2.schema.names
-      end
-    end
   end
 end

--- a/lib/related/operations/semi_join.rb
+++ b/lib/related/operations/semi_join.rb
@@ -3,9 +3,9 @@ module Related
     def left_semi_join(other)
       mapping = schema.join_mapping_for other.schema
       Relation.new(schema.similar) do |r|
-        each do |tuple|
-          other.each do |other_tuple|
-            r.add_tuple tuple if tuple.matches?(other_tuple, index_mapping: mapping)
+        cross_action other do |tuple, other_tuple|
+          if tuple.matches? other_tuple, mapping: mapping
+            r.add_tuple tuple
           end
         end
       end
@@ -14,14 +14,7 @@ module Related
     alias semi_join left_semi_join
 
     def right_semi_join(other)
-      mapping = schema.join_mapping_for other.schema
-      Relation.new(other.schema.similar) do |r|
-        each do |tuple|
-          other.each do |other_tuple|
-            r.add_tuple other_tuple if tuple.matches?(other_tuple, index_mapping: mapping)
-          end
-        end
-      end
+      other.left_semi_join self
     end
     alias ⋊ right_semi_join
   end

--- a/lib/related/relation.rb
+++ b/lib/related/relation.rb
@@ -46,13 +46,20 @@ module Related
     end
     alias π project
 
+    def cross_action(other)
+      return if !block_given?
+      tuples.each do |tuple|
+        other.tuples.each do |other_tuple|
+          yield tuple, other_tuple
+        end
+      end
+    end
+
     def cross_product(other)
       Relation.new do |r|
         r.schema = Schema.new(schema.heading + other.schema.heading)
-        tuples.each do |tuple|
-          other.tuples.each do |other_tuple|
-            r.add_tuple tuple + other_tuple
-          end
+        cross_action other do |tuple, other_tuple|
+          r.add_tuple tuple + other_tuple
         end
       end
     end
@@ -98,8 +105,8 @@ module Related
       to_table
     end
 
-		def clone
-			Relation.new @schema.clone, @tuples.clone
-		end
+    def clone
+      Relation.new @schema.clone, @tuples.clone
+    end
   end
 end

--- a/lib/related/tuple.rb
+++ b/lib/related/tuple.rb
@@ -40,8 +40,8 @@ module Related
       values.hash
     end
 
-    def matches?(other, index_mapping:)
-      index_mapping.each do |i, j|
+    def matches?(other, mapping:)
+      mapping.each do |i, j|
         return false if values[i] != other.values[j]
       end
       true


### PR DESCRIPTION
Natural join has been rewrited to use Schema#join_mapping_for. Right
semi join definition is now reusing left semi join. And duplicated
nested each blocks have been replaced with Relation#cross_action method.
